### PR TITLE
requires python >= 3.10

### DIFF
--- a/libs/python/pyproject.toml
+++ b/libs/python/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "Asterix data processing library"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Since version 0.12.0, `match` statements have been used in `asterix/base.py`. These rely on Python 3.10+ syntax (see [PEP 636 – Structural Pattern Matching](https://peps.python.org/pep-0636/)). This pull request updates `pyproject.toml` accordingly to reflect the minimum required Python version.